### PR TITLE
Run the benchmarks and generate reports using github actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,7 @@
 name: Benchmarks
 
-# TODO Make this only run on certain branches/commits?
-on: push
+# TODO Add inputs
+on: workflow_dispatch
 
 env:
   REPORT_BRANCH: report-${{ github.run_id }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           ref: report-${{ github.run_id }}
       - run: make experiment-${{ matrix.strat }}-${{ matrix.version}}-serial
+      - run: git commit . -m "Adding experiment results"
       - run: git push -u origin $REPORT_BRANCH
 
   make-report:
@@ -40,5 +41,6 @@ jobs:
         with:
           ref: report-${{ github.run_id }}
       # TODO only genereate the report but don't rerun the tests
-      - run: make reports
+      - run: make reports-only
+      - run: git commit . -m "Adding report"
       - run: git push -u origin $REPORT_BRANCH

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,13 +5,14 @@ on: push
 jobs:
   test-benchmark:
     strategy:
-      version:
-        - 0.7.0
-        - 0.6.1
-      strat:
-        - 001indinv
-        - 002bmc
-    runs-on: ubuntu-20.04
+      matrix:
+        version:
+          - 0.7.0
+          - 0.6.1
+        strat:
+          - 001indinv
+          - 002bmc
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: make experiment-${{ matrix.strat }}-${{ matrix.version}}-serial

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -50,7 +50,7 @@ jobs:
         run: git fetch origin
       - name: Merge in report branches
         run: |
-          git for-each-ref --shell --format='%(refname:lstrip=-2)' refs/remotes/origin/${REPORT_BRANCH}* |
+          git for-each-ref --format='%(refname:lstrip=-2)' refs/remotes/origin/${REPORT_BRANCH}* |
           while read branch
           do
             git merge $branch
@@ -64,7 +64,7 @@ jobs:
           git push -u origin $REPORT_BRANCH
       - name: Cleanup intermediate branches
         run: |
-          git for-each-ref --shell --format='%(refname:lstrip=-3)' refs/remotes/origin/${REPORT_BRANCH}-*-* |
+          git for-each-ref --format='%(refname:lstrip=-3)' refs/remotes/origin/${REPORT_BRANCH}-*-* |
           while read branch
           do
             echo git push origin --delete $branch

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,8 +2,19 @@ name: Benchmarks
 
 on: push
 
+env:
+  REPORT_BRANCH: report-${{ github.run_id }}
+
 jobs:
-  test-benchmark:
+  create-report-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git checkout -b $REPORT_BRANCH
+      - run: git push -u origin $REPORT_BRANCH
+
+  run-benchmarks:
+    needs: create-report-branch
     strategy:
       matrix:
         version:
@@ -11,8 +22,23 @@ jobs:
           - 0.6.1
         strat:
           - 001indinv
-          - 002bmc
+          # FIXME
+          # - 002bmc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: report-${{ github.run_id }}
       - run: make experiment-${{ matrix.strat }}-${{ matrix.version}}-serial
+      - run: git push -u origin $REPORT_BRANCH
+
+  make-report:
+    needs: run-benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: report-${{ github.run_id }}
+      # TODO only genereate the report but don't rerun the tests
+      - run: make reports
+      - run: git push -u origin $REPORT_BRANCH

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,8 +3,15 @@ name: Benchmarks
 on: push
 
 jobs:
+  strategy:
+    version:
+      - 0.7.0
+      - 0.6.1
+    strat:
+      - 001indinv
+      - 002bmc
   test-benchmark:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: make experiment-001indinv-0.7.0-serial
+      - run: make experiment-${{ matrix.strat }}-${{ matrix.version}}-serial

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,13 +46,14 @@ jobs:
         run: |
           git config user.name github-ci
           git config user.email todo@example.com
+      - name: Fetch remote branches
+        run: git fetch origin
       - name: Merge in report branches
         run: |
-          # git for-each-ref --shell --format='%(refname:lstrip=-2)' refs/remotes/origin/${REPORT_BRANCH}* |
-          git for-each-ref --shell --format='%(refname:lstrip=-2)' |
+          git for-each-ref --shell --format='%(refname:lstrip=-2)' refs/remotes/origin/${REPORT_BRANCH}* |
           while read branch
           do
-            echo $branch
+            git merge $branch
           done
       - name: Generate reports
         run: make reports-only

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,12 +9,7 @@ on:
       - shon/github-actions # TODO: Remove before merging into shon/ci
   # TODO: Enable manual dispatch once merged into master
   # is addressed
-  # workflow_dispatch:
-  #   inputs:
-  #     foo:
-  #       description: "Foo bar"
-  #       required: false
-  #       default: "baz"
+  # workflow_dispatch
 
 env:
   REPORT_BRANCH: report-${{ github.run_id }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,7 +8,6 @@ env:
 
 jobs:
   run-benchmarks:
-    needs: create-report-branch
     strategy:
       matrix:
         version:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,4 +7,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: make experiment-001indinv-0.7.0-serial
+      - run: make --version
+      - run: make -d experiment-001indinv-0.7.0-serial

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,8 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install csvtomd dependency
-        run: pip3 install csvtomd
+        # TODO Replace with proper python dependency management
+      - name: Install python dependencies
+        run: |
+          pip3 install csvtomd matplotlib
       - name: Create report branch
         run: git checkout -b $REPORT_BRANCH
       - name: Configure git user

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,18 @@
 name: Run Benchmarks
 
+# For each combination of version and experiment suite (called "strat")
+# this workflow does the following in a dedicated build agent:
+#
+# - Creates a temporary branch for storing the results of the experiment run
+# - Runs the experiments
+# - Commits the results to the temprary branch
+#
+# Once all experiments have been run, a new agent is created which
+#
+# - merges in all the results from the temporary branches
+# - updates the report that summarizes the results for each experiment suite
+# - opens a PR into master with the updates results and reports
+
 on:
   # TODO: Change to only run on master branch
   push:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,6 +31,8 @@ jobs:
   run-benchmarks:
     strategy:
       matrix:
+        # NOTE: Any updates to the version an strat must be complemented by
+        # updates to the VERSIONS and STRATEGIES in the Makefile
         version:
           - 0.7.0
           - 0.6.1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,9 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        # TODO Replace with proper python dependency management
+      - uses: actions/setup-python@v2
       - name: Install python dependencies
         run: |
+          # TODO Replace with proper python dependency management
           pip3 install csvtomd matplotlib
       - name: Create report branch
         run: git checkout -b $REPORT_BRANCH

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,16 @@
-name: Benchmarks
+name: Run Benchmarks
 
-# TODO Add inputs
-on: workflow_dispatch
+on:
+  push
+  # TODO: Enable manual dispatch once
+  # https://github.community/t/cant-trigger-workflow-manually/121740/41?u=shonfeder
+  # is addressed
+  # workflow_dispatch:
+  #   inputs:
+  #     foo:
+  #       description: "Foo bar"
+  #       required: false
+  #       default: "baz"
 
 env:
   REPORT_BRANCH: report-${{ github.run_id }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,9 +1,13 @@
 name: Run Benchmarks
 
 on:
-  push
-  # TODO: Enable manual dispatch once
-  # https://github.community/t/cant-trigger-workflow-manually/121740/41?u=shonfeder
+  # TODO: Change to only run on master branch
+  push:
+    branches:
+      - master
+      - shon/ci # TODO: Remove before merging into master
+      - shon/github-actions # TODO: Remove before merging into shon/ci
+  # TODO: Enable manual dispatch once merged into master
   # is addressed
   # workflow_dispatch:
   #   inputs:
@@ -24,22 +28,26 @@ jobs:
           - 0.6.1
         strat:
           - 001indinv
-          # FIXME
-          # - 002bmc
+          - 002bmc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Configure git user
         run: |
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
-      - run: git checkout -b $REPORT_BRANCH-${{ matrix.strat }}-${{ matrix.version }}
+
+      - name: Create intermediate branch
+        run: git checkout -b $REPORT_BRANCH-${{ matrix.strat }}-${{ matrix.version }}
+
       - name: Run experiment ${{ matrix.strat }} for version ${{ matrix.version }}
         run: make experiment-${{ matrix.strat }}-${{ matrix.version }}-serial
+
       - name: Push results to intermediate branch
         run: |
           git add .
-          git commit . -m "Adding experiment results"
+          git commit . -m "Add results for ${{ matrix.strat }} on version ${{ matrix.version }}"
           git push -u origin $REPORT_BRANCH-${{ matrix.strat }}-${{ matrix.version }}
 
   make-report:
@@ -48,22 +56,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+
       - name: Install python dependencies
         run: |
           # TODO Replace with proper python dependency management in script
           pip3 install csvtomd matplotlib
-      # - name: Create report branch
-      #   run: git checkout -b $REPORT_BRANCH
-      # - name: Configure git user
-      #   run: |
-      #     git config user.name ${{ github.actor }}
-      #     git config user.email ${{ github.actor }}@users.noreply.github.com
+
       - name: Configure git user
         run: |
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
+
       - name: Fetch remote branches
         run: git fetch origin
+
       - name: Merge in report branches
         run: |
           git for-each-ref --format='%(refname:lstrip=-2)' refs/remotes/origin/${REPORT_BRANCH}* |
@@ -71,6 +77,7 @@ jobs:
           do
             git merge $branch
           done
+
       - name: Generate reports
         run: make reports-only
 
@@ -81,11 +88,7 @@ jobs:
           branch: report-${{ github.run_id }}
           title: Update benchmarks report
           commit-message: Update report from run ${{ github.run_id }}
-      # - name: Push report branch
-      #   run: |
-      #     git add .
-      #     git commit . -m "Adding report"
-      #     git push -u origin $REPORT_BRANCH
+
       - name: Cleanup intermediate branches
         run: |
           git for-each-ref --format='%(refname:lstrip=-1)' refs/remotes/origin/${REPORT_BRANCH}-*-* |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,8 +31,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Configure git user
         run: |
-          git config user.name github-ci
-          git config user.email todo@example.com
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
       - run: git checkout -b $REPORT_BRANCH-${{ matrix.strat }}-${{ matrix.version }}
       - name: Run experiment ${{ matrix.strat }} for version ${{ matrix.version }}
         run: make experiment-${{ matrix.strat }}-${{ matrix.version }}-serial
@@ -50,14 +50,18 @@ jobs:
       - uses: actions/setup-python@v2
       - name: Install python dependencies
         run: |
-          # TODO Replace with proper python dependency management
+          # TODO Replace with proper python dependency management in script
           pip3 install csvtomd matplotlib
-      - name: Create report branch
-        run: git checkout -b $REPORT_BRANCH
+      # - name: Create report branch
+      #   run: git checkout -b $REPORT_BRANCH
+      # - name: Configure git user
+      #   run: |
+      #     git config user.name ${{ github.actor }}
+      #     git config user.email ${{ github.actor }}@users.noreply.github.com
       - name: Configure git user
         run: |
-          git config user.name github-ci
-          git config user.email todo@example.com
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
       - name: Fetch remote branches
         run: git fetch origin
       - name: Merge in report branches
@@ -69,11 +73,19 @@ jobs:
           done
       - name: Generate reports
         run: make reports-only
-      - name: Push report branch
-        run: |
-          git add .
-          git commit . -m "Adding report"
-          git push -u origin $REPORT_BRANCH
+
+        # See https://github.com/peter-evans/create-pull-request
+      - name: Create pull request with report
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: report-${{ github.run_id }}
+          title: Update benchmarks report
+          commit-message: Update report from run ${{ github.run_id }}
+      # - name: Push report branch
+      #   run: |
+      #     git add .
+      #     git commit . -m "Adding report"
+      #     git push -u origin $REPORT_BRANCH
       - name: Cleanup intermediate branches
         run: |
           git for-each-ref --format='%(refname:lstrip=-1)' refs/remotes/origin/${REPORT_BRANCH}-*-* |
@@ -81,5 +93,3 @@ jobs:
           do
             git push origin --delete $branch
           done
-      - name: Open PR
-        run: echo "TODO"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -51,6 +51,8 @@ jobs:
           do
             git merge $branch
           done
+      - name: Generate reports
+        run: make reports-only
       - name: Push report branch
         run: |
           git add .

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,6 @@
 name: Benchmarks
 
+# TODO Make this only run on certain branches/commits?
 on: push
 
 env:
@@ -30,6 +31,8 @@ jobs:
         with:
           ref: report-${{ github.run_id }}
       - run: make experiment-${{ matrix.strat }}-${{ matrix.version}}-serial
+      - run: git config user.name github-ci
+      - run: git config user.email todo@example.com
       - run: git commit . -m "Adding experiment results"
       - run: git push -u origin $REPORT_BRANCH
 
@@ -40,7 +43,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: report-${{ github.run_id }}
-      # TODO only genereate the report but don't rerun the tests
       - run: make reports-only
+      - run: git config user.name github-ci
+      - run: git config user.email todo@example.com
       - run: git commit . -m "Adding report"
       - run: git push -u origin $REPORT_BRANCH

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,10 +67,10 @@ jobs:
           git push -u origin $REPORT_BRANCH
       - name: Cleanup intermediate branches
         run: |
-          git for-each-ref --format='%(refname:lstrip=-3)' refs/remotes/origin/${REPORT_BRANCH}-*-* |
+          git for-each-ref --format='%(refname:lstrip=-1)' refs/remotes/origin/${REPORT_BRANCH}-*-* |
           while read branch
           do
-            echo git push origin --delete $branch
+            git push origin --delete $branch
           done
       - name: Open PR
         run: echo "TODO"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,14 +3,14 @@ name: Benchmarks
 on: push
 
 jobs:
-  strategy:
-    version:
-      - 0.7.0
-      - 0.6.1
-    strat:
-      - 001indinv
-      - 002bmc
   test-benchmark:
+    strategy:
+      version:
+        - 0.7.0
+        - 0.6.1
+      strat:
+        - 001indinv
+        - 002bmc
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,5 +7,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: make debug
       - run: make experiment-001indinv-0.7.0-serial

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,4 +7,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: make debug
       - run: make experiment-001indinv-0.7.0-serial

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,6 +33,7 @@ jobs:
       - run: make experiment-${{ matrix.strat }}-${{ matrix.version}}-serial
       - run: git config user.name github-ci
       - run: git config user.email todo@example.com
+      - run: git add .
       - run: git commit . -m "Adding experiment results"
       - run: git push -u origin $REPORT_BRANCH
 
@@ -46,5 +47,6 @@ jobs:
       - run: make reports-only
       - run: git config user.name github-ci
       - run: git config user.email todo@example.com
+      - run: git add .
       - run: git commit . -m "Adding report"
       - run: git push -u origin $REPORT_BRANCH

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,5 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: make --version
-      - run: make -d experiment-001indinv-0.7.0-serial
+      - run: make experiment-001indinv-0.7.0-serial

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,10 @@
+name: Benchmarks
+
+on: push
+
+jobs:
+  test-benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make experiment-001indinv-0.7.0-serial

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,12 +30,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: report-${{ github.run_id }}
-      - run: make experiment-${{ matrix.strat }}-${{ matrix.version}}-serial
-      - run: git config user.name github-ci
-      - run: git config user.email todo@example.com
-      - run: git add .
-      - run: git commit . -m "Adding experiment results"
-      - run: git push -u origin $REPORT_BRANCH
+      - name: Configure git user
+        run: |
+          git config user.name github-ci
+          git config user.email todo@example.com
+      - run: git checkout -b $REPORT_BRANCH-${{ matrix.strat }}-${{ matrix.version }}
+      - name: Run experiment ${{ matrix.strat }} for version ${{ matrix.version }}
+        run: make experiment-${{ matrix.strat }}-${{ matrix.version }}-serial
+      - name: Push results to intermediate branch
+        run: |
+          git add .
+          git commit . -m "Adding experiment results"
+          git push -u origin $REPORT_BRANCH-${{ matrix.strat }}-${{ matrix.version }}
 
   make-report:
     needs: run-benchmarks
@@ -44,9 +50,28 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: report-${{ github.run_id }}
-      - run: make reports-only
-      - run: git config user.name github-ci
-      - run: git config user.email todo@example.com
-      - run: git add .
-      - run: git commit . -m "Adding report"
-      - run: git push -u origin $REPORT_BRANCH
+      - name: Configure git user
+        run: |
+          git config user.name github-ci
+          git config user.email todo@example.com
+      - name: Merge in report branches
+        run: |
+          git for-each-ref --shell --format='%(refname:lstrip=-2)' refs/remotes/origin/${REPORT_BRANCH}* |
+          while read branch
+          do
+            git merge $branch
+          done
+      - name: Make report branch
+        run: |
+          git add .
+          git commit . -m "Adding report"
+          git push -u origin $REPORT_BRANCH
+      - name: Cleanup intermediate branches
+        run: |
+          git for-each-ref --shell --format='%(refname:lstrip=-3)' refs/remotes/origin/${REPORT_BRANCH}-*-* |
+          while read branch
+          do
+            echo git push origin --delete $branch
+          done
+      - name: Open PR
+        run: echo "TODO"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install csvtomd dependency
+        run: pip3 install csvtomd
       - name: Create report branch
         run: git checkout -b $REPORT_BRANCH
       - name: Configure git user
@@ -46,10 +48,11 @@ jobs:
           git config user.email todo@example.com
       - name: Merge in report branches
         run: |
-          git for-each-ref --shell --format='%(refname:lstrip=-2)' refs/remotes/origin/${REPORT_BRANCH}* |
+          # git for-each-ref --shell --format='%(refname:lstrip=-2)' refs/remotes/origin/${REPORT_BRANCH}* |
+          git for-each-ref --shell --format='%(refname:lstrip=-2)' |
           while read branch
           do
-            git merge $branch
+            echo $branch
           done
       - name: Generate reports
         run: make reports-only

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,13 +7,6 @@ env:
   REPORT_BRANCH: report-${{ github.run_id }}
 
 jobs:
-  create-report-branch:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: git checkout -b $REPORT_BRANCH
-      - run: git push -u origin $REPORT_BRANCH
-
   run-benchmarks:
     needs: create-report-branch
     strategy:
@@ -28,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: report-${{ github.run_id }}
       - name: Configure git user
         run: |
           git config user.name github-ci
@@ -48,8 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: report-${{ github.run_id }}
+      - name: Create report branch
+        run: git checkout -b $REPORT_BRANCH
       - name: Configure git user
         run: |
           git config user.name github-ci
@@ -61,7 +52,7 @@ jobs:
           do
             git merge $branch
           done
-      - name: Make report branch
+      - name: Push report branch
         run: |
           git add .
           git commit . -m "Adding report"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   test-benchmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: make debug

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,6 @@ BASEDIR=$(shell pwd)
 RUN_DIR=$(BASEDIR)/runs
 RES_DIR=$(BASEDIR)/results
 
-.PHONY: debug
-debug:
-	echo $(BASEDIR)
-	echo $(shell ls $(BASEDIR))
-	echo $(RUN_DIR)
-	echo $(RES_DIR)
 ##########
 # MACROS #
 ##########

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endef
 
 define experiment-strat-version-serial
 .PHONY: experiment-$(1)-$(2)-serial
-experiment-$(1)-$(2)-serial: docker-pull $(RES_DIR) $(RUN_DIR)/$(1)-apalache-$(2)/
+experiment-$(1)-$(2)-serial: docker-pull res-dir $(RUN_DIR)/$(1)-apalache-$(2)
 	@echo
 	@echo "======> Running experiments for" experiment-$(1)-$(2)-serial
 	@echo
@@ -82,7 +82,7 @@ endef
 # PHONY TARGETS #
 #################
 
-.PHONY: reports experiments docker-pull clean
+.PHONY: reports experiments docker-pull clean run-dir res-dir
 
 ###########
 # REPORTS #
@@ -134,7 +134,7 @@ experiments-serial: $(foreach s, $(STRATEGIES), $(foreach v, $(VERSIONS), experi
 #
 # The pattern % will look like <strategy>-apalache-<version>
 # for the given STRATEGY and VERSION
-$(RES_DIR)/%.csv: docker-pull $(RES_DIR) $(RUN_DIR)/%/
+$(RES_DIR)/%.csv: docker-pull res-dir $(RUN_DIR)/%
 	@echo
 	@echo "======> Running experiments for" $*
 	@echo
@@ -147,7 +147,7 @@ $(RES_DIR)/%.csv: docker-pull $(RES_DIR) $(RUN_DIR)/%/
 #
 # The pattern % will look like <strategy>-apalache-<version>
 # for the given STRATEGY and VERSION
-$(RUN_DIR)/%/: $(RUN_DIR)
+$(RUN_DIR)/%: run-dir
 	@echo
 	@echo "======> Generating runner scripts for" $*
 	@echo
@@ -170,10 +170,10 @@ $(RUN_DIR)/%/: $(RUN_DIR)
 docker-pull:
 	$(BASEDIR)/scripts/pull-docker-images.sh $(VERSIONS)
 
-$(RUN_DIR):
+run-dir:
 	make -p $(RUN_DIR)
 
-$(RES_DIR):
+res-dir:
 	make -p $(RES_DIR)
 
 

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ VERSIONS := \
 # NOTE: Currently, only param files from the ./performance directory are
 # supported.
 STRATEGIES := \
-001indinv \
-002bmc
+001indinv # \ FIXME
+# 002bmc
 
 
 #####################
@@ -96,7 +96,9 @@ $(RES_DIR)/%-report.md: $(call strategy_results,%)
 	cd ./results && \
 		$(BASEDIR)/scripts/mk-report.sh $(BASEDIR)/performance/$*-apalache.csv $^ >$@
 
-# Generate the reports but don't run any of the tests
+# Generate the reports based on existin test data
+# but don't run any of the tests.
+#
 # Used in the CI pipeline
 reports-only:
 	cd ./results \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endef
 
 define experiment-strat-version-serial
 .PHONY: experiment-$(1)-$(2)-serial
-experiment-$(1)-$(2)-serial: docker-pull $(RES_DIR) $(RUN_DIR)/$(1)-apalache-$(2)
+experiment-$(1)-$(2)-serial: docker-pull $(RES_DIR) $(RUN_DIR)/$(1)-apalache-$(2)/
 	@echo
 	@echo "======> Running experiments for" experiment-$(1)-$(2)-serial
 	@echo
@@ -134,7 +134,7 @@ experiments-serial: $(foreach s, $(STRATEGIES), $(foreach v, $(VERSIONS), experi
 #
 # The pattern % will look like <strategy>-apalache-<version>
 # for the given STRATEGY and VERSION
-$(RES_DIR)/%.csv: docker-pull $(RES_DIR) $(RUN_DIR)/%
+$(RES_DIR)/%.csv: docker-pull $(RES_DIR) $(RUN_DIR)/%/
 	@echo
 	@echo "======> Running experiments for" $*
 	@echo
@@ -147,7 +147,7 @@ $(RES_DIR)/%.csv: docker-pull $(RES_DIR) $(RUN_DIR)/%
 #
 # The pattern % will look like <strategy>-apalache-<version>
 # for the given STRATEGY and VERSION
-$(RUN_DIR)/%: $(RUN_DIR)
+$(RUN_DIR)/%/: $(RUN_DIR)
 	@echo
 	@echo "======> Generating runner scripts for" $*
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ VERSIONS := \
 # NOTE: Currently, only param files from the ./performance directory are
 # supported.
 STRATEGIES := \
-001indinv # \ FIXME
-# 002bmc
+001indinv \
+002bmc
 
 
 #####################

--- a/Makefile
+++ b/Makefile
@@ -170,10 +170,10 @@ docker-pull:
 	$(BASEDIR)/scripts/pull-docker-images.sh $(VERSIONS)
 
 runs:
-	make -p $(RUN_DIR)
+	mkdir -p $(RUN_DIR)
 
 results:
-	make -p $(RES_DIR)
+	mkdir -p $(RES_DIR)
 
 
 ###########

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endef
 
 define experiment-strat-version-serial
 .PHONY: experiment-$(1)-$(2)-serial
-experiment-$(1)-$(2)-serial: docker-pull results $(RUN_DIR)/$(1)-apalache-$(2)
+experiment-$(1)-$(2)-serial: $(RUN_DIR)/$(1)-apalache-$(2) | docker-pull results
 	@echo
 	@echo "======> Running experiments for" experiment-$(1)-$(2)-serial
 	@echo
@@ -146,7 +146,7 @@ experiments-serial: $(foreach s, $(STRATEGIES), $(foreach v, $(VERSIONS), experi
 #
 # The pattern % will look like <strategy>-apalache-<version>
 # for the given STRATEGY and VERSION
-$(RES_DIR)/%.csv: docker-pull results $(RUN_DIR)/%
+$(RES_DIR)/%.csv: $(RUN_DIR)/% | docker-pull results
 	@echo
 	@echo "======> Running experiments for" $*
 	@echo
@@ -159,7 +159,7 @@ $(RES_DIR)/%.csv: docker-pull results $(RUN_DIR)/%
 #
 # The pattern % will look like <strategy>-apalache-<version>
 # for the given STRATEGY and VERSION
-$(RUN_DIR)/%: runs
+$(RUN_DIR)/%: | runs
 	@echo
 	@echo "======> Generating runner scripts for" $*
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@
 # BASIC ELEMENTS #
 ##################
 
+# NOTE: Any updates to the VERSIONS and STRATEGIS must be complemented by
+# updates to the `version` and `strat` in the build matrix in
+# .github/workflow/benchmarks.yml
+
 # These are the fundamental elements determining what benchmarks are run
 
 # The versions of apalache to benchmark

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endef
 
 define experiment-strat-version-serial
 .PHONY: experiment-$(1)-$(2)-serial
-experiment-$(1)-$(2)-serial: docker-pull res-dir $(RUN_DIR)/$(1)-apalache-$(2)
+experiment-$(1)-$(2)-serial: docker-pull results $(RUN_DIR)/$(1)-apalache-$(2)
 	@echo
 	@echo "======> Running experiments for" experiment-$(1)-$(2)-serial
 	@echo
@@ -82,7 +82,7 @@ endef
 # PHONY TARGETS #
 #################
 
-.PHONY: reports experiments docker-pull clean run-dir res-dir
+.PHONY: reports experiments docker-pull clean
 
 ###########
 # REPORTS #
@@ -134,7 +134,7 @@ experiments-serial: $(foreach s, $(STRATEGIES), $(foreach v, $(VERSIONS), experi
 #
 # The pattern % will look like <strategy>-apalache-<version>
 # for the given STRATEGY and VERSION
-$(RES_DIR)/%.csv: docker-pull res-dir $(RUN_DIR)/%
+$(RES_DIR)/%.csv: docker-pull results $(RUN_DIR)/%
 	@echo
 	@echo "======> Running experiments for" $*
 	@echo
@@ -147,7 +147,7 @@ $(RES_DIR)/%.csv: docker-pull res-dir $(RUN_DIR)/%
 #
 # The pattern % will look like <strategy>-apalache-<version>
 # for the given STRATEGY and VERSION
-$(RUN_DIR)/%: run-dir
+$(RUN_DIR)/%: runs
 	@echo
 	@echo "======> Generating runner scripts for" $*
 	@echo
@@ -170,10 +170,10 @@ $(RUN_DIR)/%: run-dir
 docker-pull:
 	$(BASEDIR)/scripts/pull-docker-images.sh $(VERSIONS)
 
-run-dir:
+runs:
 	make -p $(RUN_DIR)
 
-res-dir:
+results:
 	make -p $(RES_DIR)
 
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,14 @@ BASEDIR=$(shell pwd)
 RUN_DIR=$(BASEDIR)/runs
 RES_DIR=$(BASEDIR)/results
 
-
+.PHONY: debug
+debug:
+	echo $(BASEDIR)
+	$(shell ls $(BASEDIR))
+	echo $(RUN_DIR)
+	$(shell ls $(RUN_DIR))
+	echo $(RES_DIR)
+	$(shell ls $(RES_DIR))
 ##########
 # MACROS #
 ##########

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,9 @@ RES_DIR=$(BASEDIR)/results
 .PHONY: debug
 debug:
 	echo $(BASEDIR)
-	$(shell ls $(BASEDIR))
+	echo $(shell ls $(BASEDIR))
 	echo $(RUN_DIR)
-	$(shell ls $(RUN_DIR))
 	echo $(RES_DIR)
-	$(shell ls $(RES_DIR))
 ##########
 # MACROS #
 ##########

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ endef
 # PHONY TARGETS #
 #################
 
-.PHONY: reports experiments docker-pull clean
+.PHONY: reports reports-only experiments docker-pull clean
 
 ###########
 # REPORTS #
@@ -95,6 +95,19 @@ reports: $(foreach s, $(STRATEGIES), $(RES_DIR)/$(s)-report.md)
 $(RES_DIR)/%-report.md: $(call strategy_results,%)
 	cd ./results && \
 		$(BASEDIR)/scripts/mk-report.sh $(BASEDIR)/performance/$*-apalache.csv $^ >$@
+
+# Generate the reports but don't run any of the tests
+# Used in the CI pipeline
+reports-only:
+	cd ./results \
+	$(foreach s, $(STRATEGIES), \
+		&& \
+		$(BASEDIR)/scripts/mk-report.sh \
+			$(BASEDIR)/performance/$(s)-apalache.csv \
+			$(call strategy_results,$(s)) \
+			> $(RES_DIR)/$(s)-report.md \
+	)
+
 
 ###############
 # EXPERIMENTS #

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ and [bounded model checking](results/002bmc-report.md).
 
 ## Parametric benchmarks
 
-Here we collect benchmarks that can be scaled according to some parameter. 
+Here we collect benchmarks that can be scaled according to some parameter.
 They are helpful to assess how various model checking methods scale wrt. the parameter.
 
 See the results for:
-  * [set addition](results/003SetAdd-report.md)
-  * [set addition and deletion](results/004SetAddDel-report.md)
-  * [set send and receive](results/005SetSndRcv-report.md)
-  * [set send and receive with unreachable error state](results/006SetSndRcv_NoFullDrop-report.md)
-  * [set send and receive with unreachable error state, encoded with cardinalities](results/007SetSndRcv_NoFullDropCard-report.md)
-  * [integer clocks](results/008IntClocks-report.md)
-  * [integer clocks with unreachable error state](results/009IntClocks_Bounded-report.md)
 
+- [set addition](results/003SetAdd-report.md)
+- [set addition and deletion](results/004SetAddDel-report.md)
+- [set send and receive](results/005SetSndRcv-report.md)
+- [set send and receive with unreachable error state](results/006SetSndRcv_NoFullDrop-report.md)
+- [set send and receive with unreachable error state, encoded with cardinalities](results/007SetSndRcv_NoFullDropCard-report.md)
+- [integer clocks](results/008IntClocks-report.md)
+- [integer clocks with unreachable error state](results/009IntClocks_Bounded-report.md)
 
 In these benchmarks we compare how symbolic approach of Apalache v. 0.7.0 behaves compared to explicit state model checking of TLC, and to the quantified SMT encoding of bounded model checking, solved with Z3. As we compare Apalache v. 0.7.0, against TLC and Z3, bundled with the current build of Apalache, we show v. 0.7.0 for those tools as well -- their actual versions are different!
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In these benchmarks we compare how symbolic approach of Apalache v. 0.7.0 behave
 
 - [time](https://www.gnu.org/software/time/)
 
-### Running the benchmarks
+### Running the benchmarks Locally
 
 To build all the sources and generate the reports, run
 
@@ -56,6 +56,16 @@ make
 ```
 
 New reports are saved into [./results](./results).
+
+### Running the benchmarkd through CI
+
+The configuration for github actions to run the benchmarks via CI is defined in
+[.github/workflows/benchmarks.yml][benchmarks.yml].
+
+When the `master` branch is updated, the workflow runs all experiments,
+generates the summary report, and opens a PR into `master` with the results.
+
+[benchmarks.yml]: ./.github/workflows/benchmarks.yml
 
 ## Warning
 

--- a/scripts/mk-run.py
+++ b/scripts/mk-run.py
@@ -123,8 +123,7 @@ def setup_experiment(args, ini_params, row_num, csv_row):
     # create the script to run an individual experiment
     script = os.path.join(exp_dir, "run-one.sh")
     cmd = tool_cmd(args, ini_params, exp_dir, tla_basename, csv_row)
-    contents = f"""
-#!/bin/bash
+    contents = f"""#!/bin/bash
 D=`dirname $0` && D=`cd "$D"; pwd` && cd "$D"
 {cmd}
 exitcode="$?"


### PR DESCRIPTION

Towards #2

Note that this PR is into the `shon/ci` branch, not `master`.

This CI configuration defines a workflow in github actions to run the benchmark suites. 

The following description of the process is included in the configuration file (see d38af27):

```
# For each combination of version and experiment suite (called "strat")
# this workflow does the following in a dedicated build agent:
#
# - Creates a temporary branch for storing the results of the experiment run
# - Runs the experiments
# - Commits the results to the temprary branch
#
# Once all experiments have been run, a new agent is created which
#
# - merges in all the results from the temporary branches
# - updates the report that summarizes the results for each experiment suite
# - opens a PR into master with the updates results and reports
```

- The latest run of the workflow (as of the time of writing): https://github.com/informalsystems/apalache-tests/actions/runs/200702266
- The PR the bot opened with the results of the benchmark runs: https://github.com/informalsystems/apalache-tests/pull/12  
  - It took just under 4 hours to complete the benchmarks.
  - Note that the recorded max memory usage is currently inaccurate, for the reason explained here https://github.com/informalsystems/apalache-tests/pull/9#issuecomment-664469191. If we agree that this CI strategy is acceptable, then fixing the memory reporting will be the next step.