### PR TITLE
Refactor the makefile to allow specifing version and strategy dynamically

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,17 @@
+# This function is to protect local variables from polluting downstream scripts
+# that source this one.
+exports () {
+    # The directory of this file
+    local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+    # Add executables to path
+    if [ -n "$APALACHE_VERSION" ]
+    then
+        export PATH=$DIR/_apalache/apalache-"$APALACHE_VERSION"/bin:$PATH
+    else
+        echo "warning: no apalache version set"
+        echo "export, e.g., APALACHE_VERSION=0.9.0, and then load .envrc again"
+    fi
+}
+
+exports

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 runs
 /_apalache/
+Pipfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 runs
+/_apalache/

--- a/Makefile
+++ b/Makefile
@@ -2,39 +2,59 @@
 #
 # Igor Konnov, 2020
 
-# The directory where the builds of apalache are stored.
-# The builds should be checked out before make is started.
-BUILDS_DIR=$(HOME)/devl
 BASEDIR=$(shell pwd)
+
+# Where we store the apalache binary
+APALCHE_DIR=$(BASEDIR)/_apalache
+# Where we run experiments
 RUN_DIR=$(BASEDIR)/runs
+# Where we save results
 RES_DIR=$(BASEDIR)/results
 
-REPORTS=$(RES_DIR)/002bmc-report.md $(RES_DIR)/001indinv-report.md
+# REPORTS=$(RES_DIR)/002bmc-report.md $(RES_DIR)/001indinv-report.md
 
-report: $(REPORTS)
+# report: $(REPORTS)
 
-$(RES_DIR)/001indinv-report.md: \
-		$(RES_DIR)/001indinv-apalache-0.7.0.csv \
-		$(RES_DIR)/001indinv-apalache-0.6.0.csv \
-		$(RES_DIR)/001indinv-apalache-0.5.2.csv
+# TODO record machine architecture and specs in reports
+
+results := $(wildcard $(RES_DIR)/*.*.*.csv)
+
+run: 
+	echo "RESULTS"
+	echo $(results)
+	echo ">>>>>>>>"
+	echo $(RES_DIR)
+	echo $(indinv_reports)
+
+report: $(RES_DIR)/$(strat)-report.md
+	echo "Finished generating report for $(strat) with apalache $(version)"
+
+# Our deps are just those results that include start as a substring
+$(RES_DIR)/$(strat)-report.md: $(foreach r,$(results),$(if $(findstring $(strat),$(r)),$(r),))
+	echo "building $(strat)-report.md from: $^"
 	cd ./results && \
-		$(BASEDIR)/scripts/mk-report.sh $(BASEDIR)/performance/001indinv-apalache.csv $^ >$@
+	 	$(BASEDIR)/scripts/mk-report.sh $(BASEDIR)/performance/$(strat)-apalache.csv $^ >$@
 
-$(RES_DIR)/002bmc-report.md: \
-		$(RES_DIR)/002bmc-apalache-0.7.0.csv \
-		$(RES_DIR)/002bmc-apalache-0.6.0.csv \
-		$(RES_DIR)/002bmc-apalache-0.5.2.csv
-	cd ./results && \
-		$(BASEDIR)/scripts/mk-report.sh $(BASEDIR)/performance/002bmc-apalache.csv $^ >$@
+# $(RES_DIR)/001indinv-report.md: $(indinv_reports)
+# 	cd ./results && \
+# 		$(BASEDIR)/scripts/mk-report.sh $(BASEDIR)/performance/001indinv-apalache.csv $^ >$@
+
+# $(RES_DIR)/002bmc-report.md: \
+# 		$(RES_DIR)/002bmc-apalache-0.7.0.csv \
+# 		$(RES_DIR)/002bmc-apalache-0.6.0.csv \
+# 		$(RES_DIR)/002bmc-apalache-0.5.2.csv
+# 	cd ./results && \
+# 		$(BASEDIR)/scripts/mk-report.sh $(BASEDIR)/performance/002bmc-apalache.csv $^ >$@
 
 # can we avoid duplication between 02bmc-apalache and 01indinv-apalache?
-$(RES_DIR)/001indinv-apalache-%.csv: prepare apalache-%
-	$(eval $@_NAME=001indinv-apalache-$*) # set the temporary variable
-	$(BASEDIR)/scripts/mk-run.py ./performance/001indinv-apalache.csv \
-		$(BUILDS_DIR)/apalache-$* ./performance $(RUN_DIR)/$($@_NAME)
-	(cd $(RUN_DIR)/$($@_NAME) && ./run-parallel.sh && \
-		$(BASEDIR)/scripts/parse-logs.py . && \
-		cp results.csv $(RES_DIR)/$($@_NAME).csv)
+$(RES_DIR)/001indinv-apalache-%.csv: # prepare apalache-%
+	echo "YEP"
+	# $(eval $@_NAME=001indinv-apalache-$*) # set the temporary variable
+	# $(BASEDIR)/scripts/mk-run.py ./performance/001indinv-apalache.csv \
+	# 	$(BUILDS_DIR)/apalache-$* ./performance $(RUN_DIR)/$($@_NAME)
+	# (cd $(RUN_DIR)/$($@_NAME) && ./run-parallel.sh && \
+	# 	$(BASEDIR)/scripts/parse-logs.py . && \
+	# 	cp results.csv $(RES_DIR)/$($@_NAME).csv)
 
 # can we avoid duplication between 02bmc-apalache and 01indinv-apalache?
 $(RES_DIR)/002bmc-apalache-%.csv: prepare apalache-%
@@ -45,18 +65,20 @@ $(RES_DIR)/002bmc-apalache-%.csv: prepare apalache-%
 		$(BASEDIR)/scripts/parse-logs.py . && \
 		cp results.csv $(RES_DIR)/$($@_NAME).csv)
 
-build: apalache-0.5.2 apalache-0.6.0 apalache-0.7.0
+# build: apalache-0.5.2 apalache-0.6.0 apalache-0.7.0
 
-apalache-0.5.2:
-	make -C $(BUILDS_DIR)/apalache-0.5.2
+# apalache-0.5.2:
+# 	make -C $(BUILDS_DIR)/apalache-0.5.2
 
-apalache-0.6.0:
-	make -C $(BUILDS_DIR)/apalache-0.6.0
+# apalache-0.6.0:
+# 	make -C $(BUILDS_DIR)/apalache-0.6.0
 
-apalache-0.7.0:
-	make -C $(BUILDS_DIR)/apalache-0.7.0
+# apalache-0.7.0:
+# 	make -C $(BUILDS_DIR)/apalache-0.7.0
 
+apalache-$(version):
 prepare:
+	mkdir -p $(RUN_DIR)
 	mkdir -p $(RUN_DIR)
 	mkdir -p $(RES_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 BASEDIR=$(shell pwd)
 
 # Where we store the apalache binary
-APALCHE_DIR=$(BASEDIR)/_apalache
+APALACHE_DIR=$(BASEDIR)/_apalache
 # Where we run experiments
 RUN_DIR=$(BASEDIR)/runs
 # Where we save results
@@ -19,19 +19,23 @@ RES_DIR=$(BASEDIR)/results
 
 results := $(wildcard $(RES_DIR)/*.*.*.csv)
 
-run: 
-	echo "RESULTS"
-	echo $(results)
-	echo ">>>>>>>>"
-	echo $(RES_DIR)
-	echo $(indinv_reports)
+strategies := 001indinv 002bmd
 
-report: $(RES_DIR)/$(strat)-report.md
-	echo "Finished generating report for $(strat) with apalache $(version)"
+help:
+	@echo "To run benchmarks for version 'l.m.n' using strategy 's' run"
+	@echo
+	@echo "    make report version=l.m.n strat=s"
+	@echo
+	@echo "where"
+	@echo
+	@echo "  - 's' is one of $(strategies)"
+	@echo "  - 'l.m.n' is >= 0.7.3"
+
+report: $(RES_DIR)/$(strat)-report.md verify-vars
 
 # Our deps are just those results that include start as a substring
 $(RES_DIR)/$(strat)-report.md: $(foreach r,$(results),$(if $(findstring $(strat),$(r)),$(r),))
-	echo "building $(strat)-report.md from: $^"
+	@echo ">> Building $(@F) from: $^"
 	cd ./results && \
 	 	$(BASEDIR)/scripts/mk-report.sh $(BASEDIR)/performance/$(strat)-apalache.csv $^ >$@
 
@@ -47,8 +51,17 @@ $(RES_DIR)/$(strat)-report.md: $(foreach r,$(results),$(if $(findstring $(strat)
 # 		$(BASEDIR)/scripts/mk-report.sh $(BASEDIR)/performance/002bmc-apalache.csv $^ >$@
 
 # can we avoid duplication between 02bmc-apalache and 01indinv-apalache?
-$(RES_DIR)/001indinv-apalache-%.csv: # prepare apalache-%
-	echo "YEP"
+$(RES_DIR)/$(strat)-apalache-$(version).csv: prepare apalache-v$(version) strat-is-defined
+	$(eval $@_NAME=$(strat)-apalache-$(version)) # set the temporary variable
+	$(BASEDIR)/scripts/mk-run.py ./performance/$(strat)-apalache.csv \
+		$(APALACHE_DIR)/apalache-$(version) ./performance $(RUN_DIR)/$($@_NAME)
+	(cd $(RUN_DIR)/$($@_NAME) && ./run-parallel.sh && \
+		$(BASEDIR)/scripts/parse-logs.py . && \
+		cp results.csv $(RES_DIR)/$($@_NAME).csv)
+
+# can we avoid duplication between 02bmc-apalache and 01indinv-apalache?
+# $(RES_DIR)/001indinv-apalache-%.csv: # prepare apalache-%
+# 	echo "YEP"
 	# $(eval $@_NAME=001indinv-apalache-$*) # set the temporary variable
 	# $(BASEDIR)/scripts/mk-run.py ./performance/001indinv-apalache.csv \
 	# 	$(BUILDS_DIR)/apalache-$* ./performance $(RUN_DIR)/$($@_NAME)
@@ -57,32 +70,44 @@ $(RES_DIR)/001indinv-apalache-%.csv: # prepare apalache-%
 	# 	cp results.csv $(RES_DIR)/$($@_NAME).csv)
 
 # can we avoid duplication between 02bmc-apalache and 01indinv-apalache?
-$(RES_DIR)/002bmc-apalache-%.csv: prepare apalache-%
-	$(eval $@_NAME=002bmc-apalache-$*) # set the temporary variable
-	$(BASEDIR)/scripts/mk-run.py ./performance/002bmc-apalache.csv \
-		$(BUILDS_DIR)/apalache-$* ./performance $(RUN_DIR)/$($@_NAME)
-	(cd $(RUN_DIR)/$($@_NAME) && ./run-parallel.sh && \
-		$(BASEDIR)/scripts/parse-logs.py . && \
-		cp results.csv $(RES_DIR)/$($@_NAME).csv)
+# $(RES_DIR)/002bmc-apalache-%.csv: prepare apalache-%
+# 	$(eval $@_NAME=002bmc-apalache-$*) # set the temporary variable
+# 	$(BASEDIR)/scripts/mk-run.py ./performance/002bmc-apalache.csv \
+# 		$(APALCHE_DIR)/apalache-$* ./performance $(RUN_DIR)/$($@_NAME)
+# 	(cd $(RUN_DIR)/$($@_NAME) && ./run-parallel.sh && \
+# 		$(BASEDIR)/scripts/parse-logs.py . && \
+# 		cp results.csv $(RES_DIR)/$($@_NAME).csv)
 
-# build: apalache-0.5.2 apalache-0.6.0 apalache-0.7.0
+.PHONY: apalache
+# invoke as `make apalache version=0.9.0`
+apalache: $(APALACHE_DIR)/apalache-$(version) version-is-defined
 
-# apalache-0.5.2:
-# 	make -C $(BUILDS_DIR)/apalache-0.5.2
-
-# apalache-0.6.0:
-# 	make -C $(BUILDS_DIR)/apalache-0.6.0
-
-# apalache-0.7.0:
-# 	make -C $(BUILDS_DIR)/apalache-0.7.0
+$(APALACHE_DIR)/apalache-$(version):
+	@echo ">> Fetching $(@F)"
+	VERSION=$(version) $(BASEDIR)/scripts/get-apalache.sh
 
 apalache-$(version):
 prepare:
-	mkdir -p $(RUN_DIR)
+	mkdir -p $(APALACHE_DIR)
 	mkdir -p $(RUN_DIR)
 	mkdir -p $(RES_DIR)
+
+version-is-defined:
+	@test $(version) || \
+		( echo "error: variable 'version' is undefined" ;\
+			echo "run 'make help' for usage." ;\
+			exit 1)
+
+strat-is-defined:
+	@test $(strat) || \
+		( echo "error: variable 'strat' is undefined" ;\
+			echo "run 'make help' for usage." ;\
+			exit 1)
+
+verify-vars: version-is-defined strat-is-defined
 
 clean:
 	(test -d $(RUN_DIR) && rm -rf $(RUN_DIR)/*) || echo "no $(RUN_DIR)"
 	(test -d $(RES_DIR) && rm -rf $(RES_DIR)/*) || echo "no $(RES_DIR)"
+	(test -d $(APALACHE_DIR) && rm -rf $(APALACHE_DIR)/*) || echo "no $(APALACHE_DIR)"
 

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+matplotlib = "*"
+csvtomd = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ and [bounded model checking](results/002bmc-report.md).
 
 ## Parametric benchmarks
 
-Here we collect benchmarks that can be scaled according to some parameter. 
+Here we collect benchmarks that can be scaled according to some parameter.
 They are helpful to assess how various model checking methods scale wrt. the parameter.
 
 See the results for:
-  * [set addition](results/003SetAdd-report.md)
-  * [set addition and deletion](results/004SetAddDel-report.md)
-  * [set send and receive](results/005SetSndRcv-report.md)
-  * [set send and receive with unreachable error state](results/006SetSndRcv_NoFullDrop-report.md)
-  * [set send and receive with unreachable error state, encoded with cardinalities](results/007SetSndRcv_NoFullDropCard-report.md)
-  * [integer clocks](results/008IntClocks-report.md)
-  * [integer clocks with unreachable error state](results/009IntClocks_Bounded-report.md)
 
+- [set addition](results/003SetAdd-report.md)
+- [set addition and deletion](results/004SetAddDel-report.md)
+- [set send and receive](results/005SetSndRcv-report.md)
+- [set send and receive with unreachable error state](results/006SetSndRcv_NoFullDrop-report.md)
+- [set send and receive with unreachable error state, encoded with cardinalities](results/007SetSndRcv_NoFullDropCard-report.md)
+- [integer clocks](results/008IntClocks-report.md)
+- [integer clocks with unreachable error state](results/009IntClocks_Bounded-report.md)
 
 In these benchmarks we compare how symbolic approach of Apalache v. 0.7.0 behaves compared to explicit state model checking of TLC, and to the quantified SMT encoding of bounded model checking, solved with Z3. As we compare Apalache v. 0.7.0, against TLC and Z3, bundled with the current build of Apalache, we show v. 0.7.0 for those tools as well -- their actual versions are different!
 
@@ -36,6 +36,7 @@ In these benchmarks we compare how symbolic approach of Apalache v. 0.7.0 behave
 - Python3, including
   - `matplotlib` via `pip install matplotlib`
   - `csvtomd` via `pip install csvtomd`
+  - (if you use pipenv, then just `pipenv shell`)
 - [GNU Parallel](https://www.gnu.org/software/parallel/)
 
 #### On Mac OS
@@ -47,22 +48,12 @@ In these benchmarks we compare how symbolic approach of Apalache v. 0.7.0 behave
 
 - [time](https://www.gnu.org/software/time/)
 
-### Setup
-
-Set up the source code for all versions that will be tested by running
-
-```sh
-./scripts/setup-sources.sh
-```
-
-NOTE: This will create a directory `$HOME/devl` if it doesn't already exit.
-
 ### Running the benchmarks
 
-To build all the sources and generate the reports, run
+For instructions on how to run benchmarks and generate the reports, run
 
 ```sh
-make
+make help
 ```
 
 New reports are saved into [./results](./results).

--- a/scripts/get-apalache.sh
+++ b/scripts/get-apalache.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script downloads the apalache package of the given version
+# and puts it in the _apalache directory for execution
+
+VERSION=${VERSION:-''}
+
+# The directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+ROOT="$DIR"/..
+
+if [ -z "$VERSION" ]
+then
+    echo "error: must supply a version, e.g., VERSION=v0.0.0 ./use-apalache.sh"
+    exit 1
+fi
+
+tmp_dir=$(mktemp -d -t "apalache-${VERSION}-XXXXXXXXXX")
+zip_name="apalache-v${VERSION}.zip"
+dst_dir="${ROOT}/_apalache/apalache-${VERSION}"
+
+cd "$tmp_dir"
+wget "https://github.com/informalsystems/apalache/releases/download/v${VERSION}/${zip_name}"
+mkdir -p "${dst_dir}"
+unzip "${zip_name}" -d "${dst_dir}"

--- a/scripts/humanise-csv.py
+++ b/scripts/humanise-csv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Read a CSV file and make some of its columns human-readable.
 #
@@ -15,6 +15,7 @@ import sys
 
 NUM_UNITS = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"]
 TIME_UNITS = ["s", "m", "h"]
+
 
 def humanise_row(fields, row):
     """make a row human-readable"""
@@ -34,19 +35,21 @@ def humanise_row(fields, row):
 
     return row
 
+
 def transform(infile):
     reader = csv.reader(infile)
-    writer = csv.writer(sys.stdout, dialect = reader.dialect, escapechar = '"')
+    writer = csv.writer(sys.stdout, dialect=reader.dialect, escapechar='"')
     fields = None
 
     for row_arr in reader:
         out_row = row_arr
         if not fields:
-            fields = row_arr # the first row is the header
+            fields = row_arr  # the first row is the header
         else:
             out_row = humanise_row(fields, out_row)
-                
+
         writer.writerow(out_row)
+
 
 def human_power(num, divider, units):
     power = 0
@@ -59,6 +62,7 @@ def human_power(num, divider, units):
 
     return (num, fraction, units[power])
 
+
 def human_bytes(num):
     val, frac, unit = human_power(int(num), 1024, NUM_UNITS)
     if val < 10:
@@ -66,8 +70,10 @@ def human_bytes(num):
     else:
         return "%d%sB" % (val, unit)
 
+
 def human_kbytes(num):
     return human_bytes(num * 1024)
+
 
 def human_num(num):
     val, frac, unit = human_power(int(num), 1000, NUM_UNITS)
@@ -75,6 +81,7 @@ def human_num(num):
         return "%d.%d%s" % (val, int(frac / 100), unit)
     else:
         return "%d%s" % (val, unit)
+
 
 def human_sec(num):
     val, frac, unit = human_power(int(num), 60, TIME_UNITS)
@@ -85,11 +92,12 @@ def human_sec(num):
     else:
         return "%d%s" % (val, unit)
 
+
 def use():
     print("Use: {} <in.csv >out.csv".format(sys.argv[0]))
     print("")
     sys.exit(1)
 
+
 if __name__ == "__main__":
     transform(sys.stdin)
-

--- a/scripts/mk-report.sh
+++ b/scripts/mk-report.sh
@@ -2,7 +2,9 @@
 #
 # Produce a markdown report for a set of performance CSVs.
 #
-# Igor Konnov, 2020
+# Igor Konnov, Shon Feder 2020-2021
+
+set -euo pipefail
 
 if [ "$#" -lt 2 ]; then
     echo "Use: $0 benchmarks.csv result_1.csv ... result_n.csv"

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -9,8 +9,9 @@ import os.path
 import sys
 
 import matplotlib
+
 # we are running a server, do not use x11
-matplotlib.use('Agg')
+matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 import matplotlib.cbook as cbook
@@ -20,34 +21,52 @@ from matplotlib.backends.backend_pdf import PdfPages
 # We define the following linetypes in the order of preference.
 # If you run out of markers, extend this list.
 LINETYPES = [
-  'rs-', 'bo-', 'g^-', 'mv-', 'kD-', 'c<-',
-  'r^-', 'bs-', 'gv-', 'mD-', 'k<-', 'co-',
-  'rv-', 'b^-', 'go-', 'm<-', 'ko-', 'cs-'
+    "rs-",
+    "bo-",
+    "g^-",
+    "mv-",
+    "kD-",
+    "c<-",
+    "r^-",
+    "bs-",
+    "gv-",
+    "mD-",
+    "k<-",
+    "co-",
+    "rv-",
+    "b^-",
+    "go-",
+    "m<-",
+    "ko-",
+    "cs-",
 ]
+
 
 def plot(opts, x_field, x_title, y_field, y_title, out_name, csvs):
     if len(csvs) > len(LINETYPES):
         raise Exception("Ran out of line types. Extend LINETYPES in the script")
 
     for csv, marker in zip(csvs, LINETYPES):
-        data = np.genfromtxt(csv, dtype=None, delimiter=',', names=True)
+        data = np.genfromtxt(
+            csv, dtype=None, delimiter=",", names=True, encoding="utf-8"
+        )
         (name, _) = os.path.splitext(os.path.basename(csv))
         # print data.dtype.names # to see the column names
         plt.plot(data[x_field], data[y_field], marker, label=name, alpha=0.7)
 
     plt.xlabel(x_title)
 
-    if opts['logscale']:
+    if opts["logscale"]:
         plt.semilogy()
-        plt.ylabel('%s, logscale' % y_title)
+        plt.ylabel("%s, logscale" % y_title)
     else:
         plt.ylabel(y_title)
 
-    plt.grid(True, alpha=.2)
-    plt.legend(loc=0) # best
-    #pp = PdfPages(out_name)
-    #pp.savefig
-    #pp.close()
+    plt.grid(True, alpha=0.2)
+    plt.legend(loc=0)  # best
+    # pp = PdfPages(out_name)
+    # pp.savefig
+    # pp.close()
     plt.savefig(out_name, format="svg")
 
 
@@ -58,12 +77,13 @@ def usage():
     )
     sys.exit(1)
 
+
 def parse_opts(argv):
     try:
         opts, args = getopt.getopt(argv[1:], "h", ["help", "logscale"])
     except getopt.GetoptError as err:
         # print help information and exit:
-        print(err) # will print something like "option -a not recognized"
+        print(err)  # will print something like "option -a not recognized"
         usage()
         sys.exit(2)
 
@@ -77,7 +97,8 @@ def parse_opts(argv):
         else:
             assert False, "unhandled option"
 
-    return ({'logscale': logscale}, args)
+    return ({"logscale": logscale}, args)
+
 
 if __name__ == "__main__":
     (opts, args) = parse_opts(sys.argv)
@@ -93,4 +114,3 @@ if __name__ == "__main__":
     csv_names = args[5:]
 
     plot(opts, x_field, x_title, y_field, y_title, out_name, csv_names)
-


### PR DESCRIPTION
This cleans up the Makefile, and enables us parameterize the build on a particular version and strategy.
This will let us parallelize the benchmarks, by running each experiment set on a different build server, and it makes it trivial to generate new benchmarks for desired versions.