### PR TITLE
Fix version handling in CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: install apalache
         run: |
-          VERSION=unreleased ./scripts/get-apalache.sh
+          ./scripts/get-apalache.sh
           echo "version=$(cat _VERSION)" >> $GITHUB_ENV
 
       - name: set up python 3.7

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 runs
 /_apalache/
+
+# This used in CI
+_VERSION

--- a/scripts/get-apalache.sh
+++ b/scripts/get-apalache.sh
@@ -33,6 +33,8 @@ then
     mkdir -p "${dst_dir}/mod-distribution/target"
     mv bin "${dst_dir}"
     mv "mod-distribution/target/apalache-pkg-${version}-full.jar" "${dst_dir}/mod-distribution/target"
+
+    # Save the version for use in CI
     echo "${version}" > "${ROOT}/_VERSION"
 else
     # Install the release
@@ -43,4 +45,7 @@ else
     wget "https://github.com/informalsystems/apalache/releases/download/v${VERSION}/${zip_name}"
     mkdir -p "${dst_dir}"
     unzip "${zip_name}" -d "${dst_dir}"
+
+    # Save the version for use in CI
+    echo "${VERSION}" > "${ROOT}/_VERSION"
 fi


### PR DESCRIPTION
Fixes two minor oversights in the way the version was handled in #22 

The error was made apparent when #25 benchmarked master instead of the intended 0.9.0 release.