### PR TITLE
Fix default version for scheduled runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,7 +5,7 @@ on:
     # Allows manually triggering release
     inputs:
       release_version:
-        description: "Release Version (leave empty to benchmark unstable)"
+        description: "Version to benchmark (set to 'unreleased' to benchmark the unstable branch)"
         required: false
         default: "unreleased"
   schedule:
@@ -15,7 +15,7 @@ on:
     - cron: "0 0 * * 6"
 
 env:
-  VERSION: ${{ github.event.inputs.release_version }}
+  VERSION: ${{ github.event.inputs.release_version || "unreleased" }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:


### PR DESCRIPTION
Prior to this, scheduled runs were failing because no VERSION was being
set. This change uses the github action expression sublanguage to
default the version to 'unreleased' when no release version is supplied
as an input.