### PR TITLE
Fix CI config and document review process

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,4 +59,10 @@ jobs:
           git add results
           commit_msg="Add reports from v${{ env.version }}"
           git commit -m "$commit_msg"
-          hub pull-request --push --message="$commit_msg" --base="master" --reviewer=konnov,shonfeder
+          hub pull-request --push \
+            --message="$commit_msg" \
+            --message="# Review Instructions" \
+            --message="- If this is a SNAPSHOT version, please review the reports and CLOSE WITHOUT MERGING." \
+            --message="- If this a regular release, you can merge to publish the results." \
+            --base="master" \
+            --reviewer=konnov,shonfeder

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ on:
     - cron: "0 0 * * 6"
 
 env:
-  VERSION: ${{ github.event.inputs.release_version || "unreleased" }}
+  VERSION: ${{ github.event.inputs.release_version || 'unreleased' }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:


### PR DESCRIPTION
We saw in #31 that without clear instructions in the reviews, we are liable to
misunderstand the purpose of these PRs. This addition adds instructions to each
PR reporting on the benchmark results.