### PR TITLE
Update to use latest output locations

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       - name: checkout benchmarks repo
         uses: actions/checkout@v2
+        with:
+          # Fetch a non-shallow copy of repo to prevent "shallow update not
+          # allowed" errors
+          # See https://stackoverflow.com/a/62293647/1187277
+          - fetch-depth: 0
 
       - name: set up java
         uses: actions/setup-java@v1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
           # Fetch a non-shallow copy of repo to prevent "shallow update not
           # allowed" errors
           # See https://stackoverflow.com/a/62293647/1187277
-          - fetch-depth: 0
+          fetch-depth: 0
 
       - name: set up java
         uses: actions/setup-java@v1

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ make report strat=s ................: generate the report from all results of ru
 where
 
 	s is one of $(strategies)
-	v is >= 0.7.3
+	v is >= 0.7.3 or "unreleased" (to run against the head of the unstable branch)
 endef
 export helpmsg
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ New benchmarks are run automatically from the `unstable` branch of [Apalache][]
 every Saturday.
 
 You can manually trigger the benchmarks to run for a specific released version
-(or from `unstable`) by selecting "Run workflow" from the [Run Benchmarks
-action][gh-action].
+(or from `unstable` by specifying the version as `unreleased`) by selecting "Run
+workflow" from the [Run Benchmarks action][gh-action].
 
 [gh-action]: https://github.com/informalsystems/apalache-tests/actions?query=workflow%3A%22Run+Benchmarks%22
 

--- a/scripts/mk-run.py
+++ b/scripts/mk-run.py
@@ -79,7 +79,7 @@ def tool_cmd(args, ini_params, exp_dir, tla_filename, csv_row):
     ctime = "%s -f 'elapsed_sec: %%e maxresident_kb: %%M' -o time.out" % os_cmds["time"]
     ctimeout = "%s --foreground %s" % (os_cmds["timeout"], csv_row["timeout"])
     if tool == "apalache":
-        return "%s %s %s/bin/apalache-mc check --profiling=true %s %s %s %s %s %s | tee apalache.out" % (
+        return "%s %s %s/bin/apalache-mc check --profiling=true --run-dir=./out %s %s %s %s %s %s | tee apalache.out" % (
             ctime,
             ctimeout,
             args.apalacheDir,

--- a/scripts/parse-logs.py
+++ b/scripts/parse-logs.py
@@ -106,10 +106,9 @@ def parse_time(ed):
 
 
 def get_experiment_log(ed: dict, fname: str) -> Path:
-    glob_pattern = "*/" + fname
-    out_dir = Path(ed["path"]) / "_apalache-out"
+    out_dir = Path(ed["path"]) / "out"
     try:
-        return next(out_dir.glob(glob_pattern))
+        return Path(out_dir) / fname
     except StopIteration:
         raise RuntimeError(
             f"Failed to find log file {fname} in experiment directory {out_dir}"


### PR DESCRIPTION
Takes advantage of `--run-dir` to put the outputs in a stable location.

Also improves the docs on running against the latest unstable version.