### PR TITLE
Add smt-encoding "strategy"

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -58,13 +58,13 @@ jobs:
 
       - name: run benchmarks
         run: |
-          if [[ "${{ env.strategy }}" == "all" ]]
+          if [[ "${{ env.STRATEGY }}" == "all" ]]
           then
             while read strat; do
               make run strat=$strat version="${{ env.version }}"
             done < STRATEGIES
           else
-            make run strat="${{ env.strategy }}" version="${{ env.version }}"
+            make run strat="010encoding" version="${{ env.version }}"
           fi
       - name: open PR with report
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,9 +9,9 @@ on:
         required: false
         default: "unreleased"
       exp_strategy:
-        description: "Limit the benchmark runs to just the given strategy (see the STRATEGIES file for supported strategies)"
+        description: "Limit the benchmark runs to just the given strategy -- leave blank to run all strategies (see the STRATEGIES file for supported strategies)"
         required: false
-        default: "all"
+        default: ""
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Automatically prepare a minor version release every Saturday
@@ -21,7 +21,7 @@ on:
 
 env:
   VERSION: ${{ github.event.inputs.release_version || 'unreleased' }}
-  STRATEGY: ${{ github.event.inputs.exp_strategy || 'all' }}
+  STRATEGY: ${{ github.event.inputs.exp_strategy }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -58,13 +58,13 @@ jobs:
 
       - name: run benchmarks
         run: |
-          if [[ "${{ env.STRATEGY }}" == "all" ]]
+          if [[ -n "${{ env.STRATEGY }}" ]]
           then
+            make run strat="${{ env.STRATEGY }}" version="${{ env.version }}"
+          else
             while read strat; do
               make run strat=$strat version="${{ env.version }}"
             done < STRATEGIES
-          else
-            make run strat="010encoding" version="${{ env.version }}"
           fi
       - name: open PR with report
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,6 +8,10 @@ on:
         description: "Version to benchmark (set to 'unreleased' to benchmark the unstable branch)"
         required: false
         default: "unreleased"
+      exp_strategy:
+        description: "Limit the benchmark runs to just the given strategy (see the STRATEGIES file for supported strategies)"
+        required: false
+        default: "all"
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Automatically prepare a minor version release every Saturday
@@ -17,6 +21,7 @@ on:
 
 env:
   VERSION: ${{ github.event.inputs.release_version || 'unreleased' }}
+  STRATEGY: ${{ github.event.inputs.exp_strategy || 'all' }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -53,10 +58,14 @@ jobs:
 
       - name: run benchmarks
         run: |
-          while read strat; do
-            make run strat=$strat version="${{ env.version }}"
-          done < STRATEGIES
-
+          if [[ "${{ env.strategy }}" == "all" ]]
+          then
+            while read strat; do
+              make run strat=$strat version="${{ env.version }}"
+            done < STRATEGIES
+          else
+            make run strat="${{ env.strategy }}" version="${{ env.version }}"
+          fi
       - name: open PR with report
         run: |
           git config --global user.name "$GITHUB_ACTOR"

--- a/STRATEGIES
+++ b/STRATEGIES
@@ -1,2 +1,3 @@
 001indinv
 002bmc
+010encoding

--- a/performance/010encoding-apalache.csv
+++ b/performance/010encoding-apalache.csv
@@ -1,0 +1,21 @@
+no,filename,tool,timeout,init,inv,next,args
+1,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=1 --cinit=CInit1
+2,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=2 --cinit=CInit2
+3,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=3 --cinit=CInit3
+4,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=4 --cinit=CInit4
+5,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=5 --cinit=CInit5
+6,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=6 --cinit=CInit6
+7,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=7 --cinit=CInit7
+8,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=8 --cinit=CInit8
+9,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=9 --cinit=CInit9
+10,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=oopsla19 --length=10 --cinit=CInit10
+11,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=1 --cinit=CInit1
+12,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=2 --cinit=CInit2
+13,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=3 --cinit=CInit3
+14,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=4 --cinit=CInit4
+15,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=5 --cinit=CInit5
+16,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=6 --cinit=CInit6
+17,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=7 --cinit=CInit7
+18,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=8 --cinit=CInit8
+19,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=9 --cinit=CInit9
+20,array-encoding/SetAdd.tla,apalache,5m,Init,Inv,Next,--smt-encoding=arrays --length=10 --cinit=CInit10

--- a/performance/array-encoding/README.md
+++ b/performance/array-encoding/README.md
@@ -1,0 +1,3 @@
+Specs and configurations used to benchmark the array SMT encoding.
+
+See https://github.com/informalsystems/apalache/issues/360

--- a/performance/array-encoding/SetAdd.tla
+++ b/performance/array-encoding/SetAdd.tla
@@ -1,0 +1,47 @@
+---------------------------- MODULE SetAdd --------------------------
+\* In this parametric example we have N values, and a set variable, initially empty.
+\* At each step we can add one element to the set.
+\* The invariant specifies that the set is not complete,
+\* i.e., we ask whether a state where the set contains all the values is reachable.
+\* This final configuration is reachable in exactly N steps.
+\*
+\*
+\* check the spec with arguments --cinit=CInit<N> --length=<N>
+\*
+\* Andrey Kuprianov, Shon Feder 2021
+
+EXTENDS FiniteSets
+
+CONSTANT
+  \* @type: Set(Int);
+  values
+
+VARIABLE
+  \* @type: Set(Int);
+  set
+
+\* Constant intialization predicates allowing to run the spec for sets of different
+\* cardinalities
+CInit1 == values = {1}
+CInit2 == values = {1, 2}
+CInit3 == values = {1, 2, 3}
+CInit4 == values = {1, 2, 3, 4}
+CInit5 == values = {1, 2, 3, 4, 5}
+CInit6 == values = {1, 2, 3, 4, 5, 6}
+CInit7 == values = {1, 2, 3, 4, 5, 6, 7}
+CInit8 == values = {1, 2, 3, 4, 5, 6, 7, 8}
+CInit9 == values = {1, 2, 3, 4, 5, 6, 7, 8, 9}
+CInit10 == values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+Init ==
+  set = {}
+
+AddOne == 
+  \E x \in (values \ set) : set' = set \union {x}
+
+Next ==
+ AddOne
+
+Inv == set /= values
+
+=============================================================================


### PR DESCRIPTION
Towards meeting the short-term needs of https://github.com/informalsystems/apalache/issues/1099

The new strategy lets us get some immediate feedback on the performance of the array encoding vs. the oopsla encoding. The current ordering (10 using the oopsla encoding then 10 using the array encoding) is selected to show the trend in performance in the difference encodings as the length increases.

As per our discussion today, @rodrigo7491 will push any additional changes to this branch that he sees fit to meet the his near-term needs.