### PR TITLE
Allows publishing  multiple reports simultaneously

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "github@actions.ci"
-          git checkout -b "report/${{ env.version }}"
+          git checkout -b "report/${{ env.STRATEGY }}${{ env.version }}"
           git add results
           commit_msg="Add reports from v${{ env.version }}"
           git commit -m "$commit_msg"


### PR DESCRIPTION
If a report is generated in CI that selects a specific strategy, the report PR will now be on a branch that reflects that strategy. This prevents branch conflicts so multiple strategies can be run in parallel.