### PR TITLE
Fix fetching to accommodate SBT builds

### DIFF
--- a/scripts/get-apalache.sh
+++ b/scripts/get-apalache.sh
@@ -28,6 +28,7 @@ then
     git clone https://github.com/informalsystems/apalache.git
     cd apalache
     make package
+    mkdir -p "${ROOT}/_apalache"
     version=$(./script/get-version.sh)
     mv "target/universal/apalache-${version}" "${ROOT}/_apalache/apalache-${version}"
 

--- a/scripts/get-apalache.sh
+++ b/scripts/get-apalache.sh
@@ -29,7 +29,7 @@ then
     cd apalache
     make package
     version=$(./script/get-version.sh)
-    mv "target/universal/apalache-${version}" "${ROOT}/_apalache/"
+    mv "target/universal/apalache-${version}" "${ROOT}/_apalache/apalache-${version}"
 
     # Save the version for use in CI
     echo "${version}" > "${ROOT}/_VERSION"

--- a/scripts/get-apalache.sh
+++ b/scripts/get-apalache.sh
@@ -27,12 +27,9 @@ then
     cd "$tmp_dir"
     git clone https://github.com/informalsystems/apalache.git
     cd apalache
-    make build-quick
+    make package
     version=$(./script/get-version.sh)
-    dst_dir="${ROOT}/_apalache/apalache-${version}"
-    mkdir -p "${dst_dir}/mod-distribution/target"
-    mv bin "${dst_dir}"
-    mv "mod-distribution/target/apalache-pkg-${version}-full.jar" "${dst_dir}/mod-distribution/target"
+    mv "target/universal/apalache-${version}" "${ROOT}/_apalache/"
 
     # Save the version for use in CI
     echo "${version}" > "${ROOT}/_VERSION"
@@ -43,7 +40,7 @@ else
 
     cd "$tmp_dir"
     wget "https://github.com/informalsystems/apalache/releases/download/v${VERSION}/${zip_name}"
-    mkdir -p "${dst_dir}"
+    mkdir -p "${ROOT}/_apalache"
     unzip "${zip_name}" -d "${dst_dir}"
 
     # Save the version for use in CI


### PR DESCRIPTION
The benchmarks haven't been running since we switched from maven to sbt,
due to some simple changes to the packaging structure. This should get
the benchmarks back to working.